### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/plugin/src/com/microsoft/alm/plugin/events/ServerEventManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/events/ServerEventManager.java
@@ -51,7 +51,7 @@ public class ServerEventManager {
         final ServerEventListener[] localListeners;
         synchronized (this.listeners) {
             // Copy the list of listeners in case someone tries to add or remove a listener while we are looping
-            localListeners = this.listeners.toArray(new ServerEventListener[this.listeners.size()]);
+            localListeners = this.listeners.toArray(new ServerEventListener[0]);
         }
         for (int i = localListeners.length - 1; i >= 0; i--) {
             // Copy the map so no one can change it on us

--- a/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/commands/Command.java
@@ -348,7 +348,7 @@ public abstract class Command<T> {
                 lines.remove(0);
             }
         }
-        return lines.toArray(new String[lines.size()]);
+        return lines.toArray(new String[0]);
     }
 
     /**

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/treetable/CustomTreeTable.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/treetable/CustomTreeTable.java
@@ -147,7 +147,7 @@ public class CustomTreeTable<T> extends TreeTable {
         } else {
             root = null;
         }
-        return new ListTreeTableModelOnColumns(root, columnsInfos.toArray(new ColumnInfo[columnsInfos.size()]));
+        return new ListTreeTableModelOnColumns(root, columnsInfos.toArray(new ColumnInfo[0]));
     }
 
     private static <T> void addChildren(final DefaultMutableTreeNode parentNode, final ContentProvider<T> contentProvider) {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:-394237697 -->
<!-- fingerprint:1262215913 -->
<!-- fingerprint:-1136606602 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (3)
